### PR TITLE
Removed util.store from render method, created new storeTodos method

### DIFF
--- a/examples/jquery/js/app.js
+++ b/examples/jquery/js/app.js
@@ -49,7 +49,6 @@ jQuery(function ($) {
 				'/:filter': function (filter) {
 					this.filter = filter;
 					this.render();
-					this.storeTodos();
 				}.bind(this)
 			}).init('/all');
 		},
@@ -122,7 +121,6 @@ jQuery(function ($) {
 			this.todos = this.getActiveTodos();
 			this.filter = 'all';
 			this.render();
-			this.storeTodos();
 		},
 		// accepts an element from inside the `.item` div and
 		// returns the corresponding index in the `todos` array

--- a/examples/jquery/js/app.js
+++ b/examples/jquery/js/app.js
@@ -49,6 +49,7 @@ jQuery(function ($) {
 				'/:filter': function (filter) {
 					this.filter = filter;
 					this.render();
+					this.storeTodos();
 				}.bind(this)
 			}).init('/all');
 		},
@@ -83,7 +84,7 @@ jQuery(function ($) {
 
 			$('#footer').toggle(todoCount > 0).html(template);
 		},
-		store: function () {
+		storeTodos: function () {
 			util.store('todos-jquery', this.todos);
 		},
 		toggleAll: function (e) {
@@ -94,7 +95,7 @@ jQuery(function ($) {
 			});
 
 			this.render();
-			this.store();
+			this.storeTodos();
 		},
 		getActiveTodos: function () {
 			return this.todos.filter(function (todo) {
@@ -121,7 +122,7 @@ jQuery(function ($) {
 			this.todos = this.getActiveTodos();
 			this.filter = 'all';
 			this.render();
-			this.store();
+			this.storeTodos();
 		},
 		// accepts an element from inside the `.item` div and
 		// returns the corresponding index in the `todos` array
@@ -153,13 +154,13 @@ jQuery(function ($) {
 			$input.val('');
 
 			this.render();
-			this.store();
+			this.storeTodos();
 		},
 		toggle: function (e) {
 			var i = this.indexFromEl(e.target);
 			this.todos[i].completed = !this.todos[i].completed;
 			this.render();
-			this.store();
+			this.storeTodos();
 		},
 		edit: function (e) {
 			var $input = $(e.target).closest('li').addClass('editing').find('.edit');
@@ -191,12 +192,12 @@ jQuery(function ($) {
 			}
 
 			this.render();
-			this.store();
+			this.storeTodos();
 		},
 		destroy: function (e) {
 			this.todos.splice(this.indexFromEl(e.target), 1);
 			this.render();
-			this.store();
+			this.storeTodos();
 		}
 	};
 

--- a/examples/jquery/js/app.js
+++ b/examples/jquery/js/app.js
@@ -70,7 +70,6 @@ jQuery(function ($) {
 			$('#toggle-all').prop('checked', this.getActiveTodos().length === 0);
 			this.renderFooter();
 			$('#new-todo').focus();
-			util.store('todos-jquery', this.todos);
 		},
 		renderFooter: function () {
 			var todoCount = this.todos.length;
@@ -84,6 +83,9 @@ jQuery(function ($) {
 
 			$('#footer').toggle(todoCount > 0).html(template);
 		},
+		store: function () {
+			util.store('todos-jquery', this.todos);
+		},
 		toggleAll: function (e) {
 			var isChecked = $(e.target).prop('checked');
 
@@ -92,6 +94,7 @@ jQuery(function ($) {
 			});
 
 			this.render();
+			this.store();
 		},
 		getActiveTodos: function () {
 			return this.todos.filter(function (todo) {
@@ -118,6 +121,7 @@ jQuery(function ($) {
 			this.todos = this.getActiveTodos();
 			this.filter = 'all';
 			this.render();
+			this.store();
 		},
 		// accepts an element from inside the `.item` div and
 		// returns the corresponding index in the `todos` array
@@ -149,11 +153,13 @@ jQuery(function ($) {
 			$input.val('');
 
 			this.render();
+			this.store();
 		},
 		toggle: function (e) {
 			var i = this.indexFromEl(e.target);
 			this.todos[i].completed = !this.todos[i].completed;
 			this.render();
+			this.store();
 		},
 		edit: function (e) {
 			var $input = $(e.target).closest('li').addClass('editing').find('.edit');
@@ -185,10 +191,12 @@ jQuery(function ($) {
 			}
 
 			this.render();
+			this.store();
 		},
 		destroy: function (e) {
 			this.todos.splice(this.indexFromEl(e.target), 1);
 			this.render();
+			this.store();
 		}
 	};
 


### PR DESCRIPTION
The 'render' method should purely handle rendering, but it handles updating the store as well. One option is to rename the render method to something like "renderAndUpdate," but that still puts two forms of logic in one method. Instead created a new 'storeTodos' method to handle the separate logic and put the method call in each related handler (left out of destoryCompleted as it isn't necessary).